### PR TITLE
If exists, import a config file to allow for overriding script variables.

### DIFF
--- a/advanced/dnsmasq.conf
+++ b/advanced/dnsmasq.conf
@@ -7,3 +7,4 @@ interface=eth0
 listen-address=127.0.0.1
 cache-size=10000
 log-queries
+local-ttl=300

--- a/gravity.sh
+++ b/gravity.sh
@@ -16,8 +16,13 @@ sources=('https://adaway.org/hosts.txt'
 'http://winhelp2002.mvps.org/hosts.txt')
 
 # Variables for various stages of downloading and formatting the list
+adList=/etc/hosts
 origin=/etc/pihole
 piholeDir=/etc/pihole
+if [ -f $piholeDir/pihole.conf ]; then
+	. $piholeDir/pihole.conf
+fi
+
 justDomainsExtension=domains
 matter=pihole.0.matter.txt
 andLight=pihole.1.andLight.txt
@@ -25,7 +30,6 @@ supernova=pihole.2.supernova.txt
 eventHorizon=pihole.3.eventHorizon.txt
 accretionDisc=pihole.4.accretionDisc.txt
 eyeOfTheNeedle=pihole.5.wormhole.txt
-adList=/etc/hosts
 blacklist=$piholeDir/blacklist.txt
 latentBlacklist=$origin/latentBlacklist.txt
 whitelist=$piholeDir/whitelist.txt

--- a/gravity.sh
+++ b/gravity.sh
@@ -19,7 +19,7 @@ sources=('https://adaway.org/hosts.txt'
 adList=/etc/hosts
 origin=/etc/pihole
 piholeDir=/etc/pihole
-if [ -f $piholeDir/pihole.conf ]; then
+if [[ -f $piholeDir/pihole.conf ]]; then
 	. $piholeDir/pihole.conf
 fi
 


### PR DESCRIPTION
To allow for minor variations of use of the script, parsing a config file could update some of the data locations.

In my case my `/etc/pihole/pihole.conf` looks like this:

    origin=/var/run/pihole
    adList=/etc/dnsmasq.d/adList

This would make it so that I wouldn't need to modify future versions of the script.  I could also create my own "sources" list and possibly not need to tweak the script.
