### PR TITLE
Strip carriage returns on matter so that whitelists work correctly.

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -77,7 +77,7 @@ done
 
 # Find all files with the .domains extension and compile them into one file
 echo "** Aggregating list of domains..."
-find $origin/ -type f -name "*.$justDomainsExtension" -exec cat {} \; > $origin/$matter
+find $origin/ -type f -name "*.$justDomainsExtension" -exec cat {} \; | tr -d '\r' > $origin/$matter
 
 # Append blacklist entries if they exist
 if [[ -f $blacklist ]];then

--- a/gravity.sh
+++ b/gravity.sh
@@ -83,7 +83,7 @@ find $origin/ -type f -name "*.$justDomainsExtension" -exec cat {} \; | tr -d '\
 if [[ -f $blacklist ]];then
         numberOf=$(cat $blacklist | wc -l | sed 's/^[ \t]*//')
         echo "** Blacklisting $numberOf domain(s)..."
-        cat $blacklist >> /tmp/matter.txt
+        cat $blacklist >> $origin/$matter
 else
         :
 fi


### PR DESCRIPTION
If a line in `matter` had a carriage return, it would not match with entries in the whitelist.  This strips carriage returns at creation of matter.

Can probably remove the other sed and awk that does the same thing, but did so after whitelist processing.

BTW, I don't have a PI, so I can't test on it.  I can only assume it has `tr`.