### PR TITLE
Parses host only file formats now.

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -69,7 +69,7 @@ do
 		# Most of the lists downloaded are already in hosts file format but the spacing/formating is not contigious
 		# This helps with that and makes it easier to read
 		# It also helps with debugging so each stage of the script can be researched more in depth
-		echo "$data" | awk 'NF {if ($1 !~ "#") print $2}' > $saveLocation."$justDomainsExtension"
+		echo "$data" | awk 'NF {if ($1 !~ "#") { if (NF>1) {print $2} else {print $1}}}' > $saveLocation."$justDomainsExtension"
 	else
 		echo "Skipping $domain list because it does not have any new entries..."
 	fi


### PR DESCRIPTION
Previously only handled hosts file format.

Specifically, it can now handle the following list:
'http://mirror1.malwaredomains.com/files/justdomains'