### PR TITLE
Log PiHole dns stats to /var/log/pihole

### DIFF
--- a/advanced/dnsmasq.conf
+++ b/advanced/dnsmasq.conf
@@ -7,5 +7,5 @@ interface=eth0
 listen-address=127.0.0.1
 cache-size=10000
 log-queries
-log-facility=/var/log/pihole
+log-facility=/var/log/pihole.log
 local-ttl=300

--- a/advanced/dnsmasq.conf
+++ b/advanced/dnsmasq.conf
@@ -7,4 +7,5 @@ interface=eth0
 listen-address=127.0.0.1
 cache-size=10000
 log-queries
+log-facility=/var/log/pihole
 local-ttl=300


### PR DESCRIPTION
Log PiHole dns stats to /var/log/pihole
- Removes the requirement for rsyslog to be installed.
- Prevents reading the shared logfile /var/log/daemon.log
- Ensures PiHole dns stats are kept in its own logfile.