### PR TITLE
Reduce mem usage

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -131,7 +131,7 @@ echo "** Aggregating list of domains..."
 find $origin/ -type f -name "*.$justDomainsExtension" -exec cat {} \; | tr -d '\r' > $origin/$matter
 
 # Append blacklist entries if they exist
-if [[ -f $blacklist ]];then
+if [[ -r $blacklist ]];then
 	numberOf=$(cat $blacklist | sed '/^\s*$/d' | wc -l)
 	echo "** Blacklisting $numberOf domain(s)..."
 	cat $blacklist >> $origin/$matter
@@ -159,7 +159,7 @@ function gravity_advanced()
 	}
 	
 # Whitelist (if applicable) then remove duplicates and format for dnsmasq
-if [[ -f $whitelist ]];then
+if [[ -r $whitelist ]];then
 	# Remove whitelist entries
 	numberOf=$(cat $whitelist | sed '/^\s*$/d' | wc -l)
 	plural=; [[ "$numberOf" != "1" ]] && plural=s

--- a/gravity.sh
+++ b/gravity.sh
@@ -92,7 +92,7 @@ do
 			;;
 		
 		"pgl.yoyo.org") 
-			cmd="curl -s -d mimetype=plaintext -d hostformat=hosts"
+			cmd="curl -d mimetype=plaintext -d hostformat=hosts"
 			;;
 
 		# Default is a simple curl request

--- a/gravity.sh
+++ b/gravity.sh
@@ -115,8 +115,8 @@ do
 		# Most of the lists downloaded are already in hosts file format but the spacing/formating is not contigious
 		# This helps with that and makes it easier to read
 		# It also helps with debugging so each stage of the script can be researched more in depth
-		awk 'NF {if ($1 !~ "#") { if (NF>1) {print $2} else {print $1}}}' $tmpfile | \
-			sed -e 's/^[. \t]*//' -e 's/\.\.\+/./g' -e 's/[. \t]*$//' | grep "\." > $saveLocation
+        awk '($1 !~ /^#/) { if (NF>1) {print $2} else {print $1}}' $tmpfile | \
+            sed -nr -e 's/\.{2,}/./g' -e '/\./p' > $saveLocation
 		echo "Done."
 	else
 		echo "Skipping list because it does not have any new entries."


### PR DESCRIPTION
This pull aims to reduce the RAM usage needed by pihole when parsing new/updated block lists.  

The files are downloaded locally and then operated on, instead of being stored as (very large) variables in the shell script.  Some simplistic tests (query /proc/<pid>/status for RSS size) show that the code in master uses ~345,000KB when running (that's the high water mark). When processing locally, RAM usage in this case is somewhere around 8,600KB

It's important to note that the files are downloaded only if the upstream copies are newer, which should address some of the concerns mentioned in #37.  That said, if SD card IO is really that much of a concern, there should be full dependency processing to eliminate unnecessary writes.