### PR TITLE
Allow external IP as an input script parameter

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -5,8 +5,8 @@
 # This script should only be run after you have a static IP address set on the Pi
 piholeIP="$1"
 
-if [[ "$piholeIP" == "" ]]; then
-        piholeIP=$(hostname -I)    
+if [ -n "$piholeIP"]; then
+        piholeIP=$(hostname -I|xargs)        
 fi
 
 
@@ -133,7 +133,7 @@ function gravity_advanced()
 	echo "** $numberOf unique domains trapped in the event horizon."
 	# Format domain list as "192.168.x.x domain.com"
 	echo "** Formatting domains into a HOSTS file..."
-	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP "'" $0}' > $origin/$accretionDisc
+	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP	"'" $0}' > $origin/$accretionDisc
 	# Copy the file over as /etc/pihole/gravity.list so dnsmasq can use it
 	sudo cp $origin/$accretionDisc $adList
 	kill -HUP $(pidof dnsmasq)

--- a/gravity.sh
+++ b/gravity.sh
@@ -3,7 +3,12 @@
 # Compiles a list of ad-serving domains by downloading them from multiple sources 
 
 # This script should only be run after you have a static IP address set on the Pi
-piholeIP=$(hostname -I)
+piholeIP="$1"
+
+if [[ "$piholeIP" == "" ]]; then
+        piholeIP=$(hostname -I)    
+fi
+
 
 # Ad-list sources--one per line in single quotes
 sources=('https://adaway.org/hosts.txt'
@@ -128,7 +133,7 @@ function gravity_advanced()
 	echo "** $numberOf unique domains trapped in the event horizon."
 	# Format domain list as "192.168.x.x domain.com"
 	echo "** Formatting domains into a HOSTS file..."
-	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP"'" $0}' > $origin/$accretionDisc
+	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP "'" $0}' > $origin/$accretionDisc
 	# Copy the file over as /etc/pihole/gravity.list so dnsmasq can use it
 	sudo cp $origin/$accretionDisc $adList
 	kill -HUP $(pidof dnsmasq)


### PR DESCRIPTION
If user add an IP as an input parameter this IP will be used when creating the host file instead of the one coming form hostname -I. This is useful for hosts with multiple IPs

Example: ./gravity.sh 123.123.123.123

