### PR TITLE
Dialog-based installer

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -174,7 +174,7 @@ commands["Cleaning up the dashboard temp files"]="sudo rm /var/www/master.zip 2>
 commands["Creating a log file for the Pi-hole"]="sudo touch /var/log/pihole.log"; echoes+=( "Creating a log file for the Pi-hole" )
 commands["chmodding the log file"]="sudo chmod 644 /var/log/pihole.log"; echoes+=( "chmodding the log file" )
 commands["chowning the log file so stats can be displayed"]="sudo chown dnsmasq:root /var/log/pihole.log"; echoes+=( "chowning the log file so stats can be displayed" )
-commands["Initating sub-space transport of gravity"]="sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh"; echoes+=( "Initating sub-space transport of gravity" )
+commands["Initating sub-space transport of gravity"]="sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/installation/gravity.sh"; echoes+=( "Initating sub-space transport of gravity" )
 commands["Initating sub-space transport of chronometer"]="sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh"; echoes+=( "Initating sub-space transport of chronometer" )
 commands["chmodding gravity"]="sudo chmod 755 /usr/local/bin/gravity.sh"; echoes+=( "chmodding gravity" )
 commands["chmodding the chronometer"]="sudo chmod 755 /usr/local/bin/chronometer.sh"; echoes+=( "chmodding the chronometer" )

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -200,7 +200,7 @@ fi
 setStaticIPv4()
 {
 # Append these lines to /etc/dhcpcd.conf to enable a static IP
-echo "interface $ethernetDevice
+echo "interface $piholeInterface
 static ip_address=$IPv4addr/24
 static routers=$IPv4gw
 static domain_name_servers=$IPv4gw" | sudo tee -a $dhcpcdFile >/dev/null
@@ -295,5 +295,12 @@ Your Pi will restart when you close this dialog.  If you are using SSH, reconnec
 
 The install log is in /etc/phole." $r $c
 
-
-sudo reboot
+# If the current IP address equals the desired address, no change is needed
+if [[ $IPv4addr = "$(cat /tmp/piholeIP)" ]];then
+	# So just start the services
+	echo "sudo service dnsmasq start"
+	echo "sudo service lighttpd start"
+else
+	# Restart to apply the new static IP address
+	echo "sudo reboot"
+fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -29,9 +29,10 @@ IPv4mask=$(ifconfig | awk -F':' '/inet addr/ && !/127.0.0.1/ {print $4}')
 IPv4gw=$(ip route show | awk '/default\ via/ {print $3}')
 
 # IPv6 support to be added later
-#IPv6addr=$(ip addr show | awk '/scope\ global/ && /ff:fe/ {print $2}' | cut -d'/' -f1)
+#IPv6eui64=$(ip addr show | awk '/scope\ global/ && /ff:fe/ {print $2}' | cut -d'/' -f1)
+#IPv6linkLocal=$(ip addr show | awk '/inet/ && /scope\ link/ && /fe80/ {print $2}' | cut -d'/' -f1)
 
-ethernetDevice="eth0"
+availableInterfaces=$(ip link show | awk -F' ' '/[0-9]: [a-z]/ {print $2}' | grep -v "lo" | cut -d':' -f1)
 dhcpcdFile=/etc/dhcpcd.conf
 
 ####### FUCNTIONS ##########
@@ -51,7 +52,113 @@ else
 fi
 }
 
-set_static_ip()
+welcomeDialogs()
+{
+# Display the welcome dialog
+whiptail --msgbox --backtitle "Welcome" --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
+
+# Explain the need for a static address
+whiptail --msgbox --backtitle "Initating network interface" --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.
+
+In the next section, you can choose to use your current network settings (DHCP) or to manually edit them." $r $c
+}
+
+use4andor6()
+{
+# Let use select IPv4 and/or IPv6
+cmd=(whiptail --separate-output --checklist "Select Protocols" $r $c 2)
+options=(IPv4 "Block ads over IPv4" on
+         IPv6 "Block ads over IPv4" off)
+choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+clear
+for choice in $choices
+do
+    case $choice in
+        IPv4)
+            echo "IPv4 selected."
+			useIPv4=true
+            ;;
+        IPv6)
+            echo "IPv6 selected."
+			useIPv6=true
+            ;;
+    esac
+done
+}
+
+
+getStaticIPv4Settings()
+{
+# Ask if the user wannts to use DHCP settings as their static IP
+if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Do you want to use your current network settings as a static address?
+
+								IP address:    $IPv4addr
+								Subnet mask:   $IPv4mask
+								Gateway:       $IPv4gw" $r $c) then
+	# If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
+	whiptail --msgbox --backtitle "IP information" --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
+
+	If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
+
+	It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address." $r $c
+	# Nothing else to do since the variables are already set above
+else
+	# Otherwise, we need to ask the user to input their desired settings.
+	# Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
+	# Start a loop to let the user enter their information with the chance to go back and edit it if necessary
+	until [[ $ipSettingsCorrect = True ]]
+	do
+	# Ask for the IPv4 address
+	IPv4addr=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
+	if [[ $? = 0 ]];then
+    	echo "Your static IPv4 address:    $IPv4addr"
+		# Ask for the subnet mask
+		IPv4mask=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 netmask" --inputbox "Enter your desired IPv4 subnet mask" $r $c $IPv4mask 3>&1 1>&2 2>&3)
+		if [[ $? = 0 ]];then
+			echo "Your static IPv4 netmask:    $IPv4mask"
+			# Ask for the gateway
+			IPv4gw=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
+			if [[ $? = 0 ]];then
+				echo "Your static IPv4 gateway:    $IPv4gw"
+				# Give the user a chance to review their settings before moving on
+				if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Are these settings correct?
+					IP address:    $IPv4addr
+					Subnet mask:   $IPv4mask
+					Gateway:       $IPv4gw" $r $c)then
+					# If the settings are correct, then we need to set the piholeIP
+					# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script
+					echo $IPv4addr > /tmp/piholeIP
+					# After that's done, the loop ends and we move on
+					ipSettingsCorrect=True
+				else
+					# If the settings are wrong, the loop continues
+					ipSettingsCorrect=False
+				fi
+			else
+				# Cancelling gateway settings window
+				ipSettingsCorrect=False
+				echo "User canceled."
+				exit
+			fi
+		else
+			# Cancelling subnet mask settings window
+			ipSettingsCorrect=False
+			echo "User canceled."
+			exit
+		fi
+	else
+		# Cancelling IPv4 settings window
+		ipSettingsCorrect=False
+		echo "User canceled."
+		exit
+	fi
+done
+# End the if statement for DHCP vs. static
+fi
+}
+
+
+setStaticIPv4()
 {
 # Append these lines to /etc/dhcpcd.conf to enable a static IP
 echo "interface $ethernetDevice
@@ -76,6 +183,7 @@ sudo service lighttpd stop
 sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
 sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
 sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
+sudo mv /etc/crontab /etc/crontab.orig
 sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
 sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
 sudo mv /etc/crontab /etc/crontab.orig
@@ -92,94 +200,46 @@ sudo chmod 644 /var/log/pihole.log
 sudo chown dnsmasq:root /var/log/pihole.log
 sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/installation/gravity.sh
 sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
+sudo curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
 sudo chmod 755 /usr/local/bin/gravity.sh
 sudo chmod 755 /usr/local/bin/chronometer.sh
+sudo chmod 755 /usr/local/bin/whitelist.sh
 sudo /usr/local/bin/gravity.sh
 sudo service networking restart
 }
 
 ######## SCRIPT ############
+# Start the installer
+welcomeDialogs
+
 # Just back up the original Pi-hole right away since it won't take long and it gets it out of the way
 backupLegacyPihole
 
-# Display the welcome dialog
-whiptail --msgbox --backtitle "Welcome" --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
+# Let the user decide if they want to block ads over IPv4 and/or IPv6
+use4andor6
 
-# Explain the need for a static address
-whiptail --msgbox --backtitle "Initating network interface" --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.
-
-In the next section, you can choose to use your current network settings (DHCP) or to manually edit them." $r $c
-
-# Ask if the user wannts to use DHCP settings as their static IP
-if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Do you want to use your current network settings as a static address?
-
-							IP address:    $IPv4addr
-							Subnet mask:   $IPv4mask
-							Gateway:       $IPv4gw" $r $c) then
-	# If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
-	whiptail --msgbox --backtitle "IP information" --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
-
-If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
-
-It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address." $r $c
-	# Nothing else to do since the variables are already set above
+# Decide is IPv4 will be used
+if [[ "$useIPv4" = true ]];then
+	echo "Using IPv4"
+	getStaticIPv4Settings
+	setStaticIPv4
 else
-	# Otherwise, we need to ask the user to input their desired settings.
-	# Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
-	# Start a loop to let the user enter their information with the chance to go back and edit it if necessary
-	until [[ $ipSettingsCorrect = True ]]
-	do
-	# Ask for the IPv4 address
-	IPv4addr=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
-	if [[ $? = 0 ]];then
-    	echo "Your static IPv4 address:    $IPv4addr"
-		# Ask for the subnet mask
-		IPv4mask=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 netmask" --inputbox "Enter your desired IPv4 subnet mask" $r $c $IPv4mask 3>&1 1>&2 2>&3)
-		if [[ $? = 0 ]];then
-				echo "Your static IPv4 netmask:    $IPv4mask"
-				# Ask for the gateway
-				IPv4gw=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
-				if [[ $? = 0 ]];then
-						echo "Your static IPv4 gateway:    $IPv4gw"
-						# Give the user a chance to review their settings before moving on
-						if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Are these settings correct?
-							IP address:    $IPv4addr
-							Subnet mask:   $IPv4mask
-							Gateway:       $IPv4gw" $r $c)then
-							# If the settings are correct, then we need to set the piholeIP
-							# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script
-							echo $IPv4addr > /tmp/piholeIP
-							# After that's done, the loop ends and we move on
-							ipSettingsCorrect=True
-
-						else
-							# If the settings are wrong, the loop continues
-							ipSettingsCorrect=False
-						fi
-				else
-					# Cancelling gateway settings window
-					ipSettingsCorrect=False
-					echo "User canceled."
-					exit
-				fi
-		else
-			# Cancelling subnet mask settings window
-			ipSettingsCorrect=False
-			echo "User canceled."
-			exit
-		fi
-	else
-		# Cancelling IPv4 settings window
-		ipSettingsCorrect=False
-    	echo "User canceled."
-		exit
-	fi
-	done
-# End the if statement for DHCP vs. static
+	echo "IPv4 will NOT be used."
 fi
 
-# Set the static address
-set_static_ip
+# Decide is IPv6 will be used
+if [[ "$useIPv6" = true ]];then
+	whiptail --msgbox --backtitle "Coming soon..." --title "IPv6 not yet supported" "I need your help.  Consider donating at:
+
+															http://pi-hole.net/donate" $r $c
+	echo "Using IPv6"
+else
+	whiptail --msgbox --backtitle "Coming soon..." --title "IPv6 not yet supported" "I need your help.  Consider donating at:
+
+															http://pi-hole.net/donate" $r $c
+	echo "IPv6 will NOT be used."
+fi
+
 
 # Install and log everything to a file
 installPihole | tee $tmpLog

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -231,8 +231,8 @@ sudo curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/
 sudo chmod 755 /usr/local/bin/gravity.sh
 sudo chmod 755 /usr/local/bin/chronometer.sh
 sudo chmod 755 /usr/local/bin/whitelist.sh
+sudo chmod 755 /usr/local/bin/piholeLogFlush.sh
 sudo /usr/local/bin/gravity.sh
-sudo service networking restart
 }
 
 ######## SCRIPT ############

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -282,7 +282,7 @@ whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Co
 
 If you didn't use DHCP settings as your new static address, the Pi will restart after this dialog.  If you are using SSH, you may need to reconnect using the IP address above.
 
-The install log is in /etc/phole." $r $c
+The install log is in /etc/pihole." $r $c
 
 # If a custom address was set, restart
 if [[ "$rebootNeeded" = true ]];then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -205,7 +205,7 @@ XXX
 EOF
 
 # Execute the command in the background (hidden from the user, not actually a background process)
-${commands[${echoes[$k]}]} > $instalLogLoc 2>&1
+${commands[${echoes[$k]}]} > $tmpLog 2>&1
 done
 sudo mv $tmpLog $instalLogLoc$instalLogLoc
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -186,3 +186,12 @@ installPihole | tee $tmpLog
 
 # Move the log file into /etc/pihole for storage
 sudo mv $tmpLog $instalLogLoc
+
+whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using this IP: $IPv4addr.
+
+The networking service will restart after you close this dialog.  If you are using SSH, you may need to reconnect." $r $c
+
+# Start the services and restart networking
+sudo service dnsmasq start
+sudo service lighttpd start
+sudo ifdown eth0;sudo ifup eth0

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -33,7 +33,7 @@ IPv6addr=$(ip addr show | awk '/scope\ global/ && /ff:fe/ {print $2}' | cut -d'/
 backupLegacyPihole()
 {
 if [[ -f /etc/dnsmasq.d/adList.conf ]];then
-	echo "Original Pi-hole detected.  Initiating sub space transport..."
+	echo "Original Pi-hole detected.  Initiating sub space transport"
 	sudo mkdir -p /etc/pihole/original/
 	sudo mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
 	sudo mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
@@ -51,10 +51,10 @@ fi
 backupLegacyPihole
 
 # Display the welcome dialog
-whiptail --msgbox --backtitle "Welcome..." --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
+whiptail --msgbox --backtitle "Welcome" --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
 
 # Explain the need for a static address
-whiptail --msgbox --backtitle "Initating network interface..." --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.
+whiptail --msgbox --backtitle "Initating network interface" --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.
 
 In the next section, you can choose to use your current network settings (DHCP) or to manually edit them." $r $c
 
@@ -65,7 +65,7 @@ if (whiptail --title "Static IP Address" --yesno "Do you want to use your curren
 							Subnet mask:   $IPv4mask
 							Gateway:       $IPv4gw" $r $c) then
 	# If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
-	whiptail --msgbox --backtitle "IP information..." --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
+	whiptail --msgbox --backtitle "IP information" --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
 
 If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
 
@@ -78,15 +78,15 @@ else
 	until [[ $ipSettingsCorrect = True ]]
 	do
 	# Ask for the IPv4 address
-	IPv4addr=$(whiptail --backtitle "Calibrating network interface..." --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
+	IPv4addr=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
 	if [[ $? = 0 ]];then
     	echo "Your static IPv4 address:    $IPv4addr"
 		# Ask for the subnet mask
-		IPv4mask=$(whiptail --backtitle "Calibrating network interface..." --title "IPv4 netmask" --inputbox "Enter your desired IPv4 subnet mask" $r $c $IPv4mask 3>&1 1>&2 2>&3)
+		IPv4mask=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 netmask" --inputbox "Enter your desired IPv4 subnet mask" $r $c $IPv4mask 3>&1 1>&2 2>&3)
 		if [[ $? = 0 ]];then
 				echo "Your static IPv4 netmask:    $IPv4mask"
 				# Ask for the gateway
-				IPv4gw=$(whiptail --backtitle "Calibrating network interface..." --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
+				IPv4gw=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
 				if [[ $? = 0 ]];then
 						echo "Your static IPv4 gateway:    $IPv4gw"
 						# Give the user a chance to review their settings before moving on
@@ -127,50 +127,52 @@ else
 fi
 
 # These are the commands to actually install the Pi-hole
-# Create an associative array so we can display text to the user but run the associated command in the background.
-declare -A cmdsAndEchoes=([sudo apt-get update]='Updating...'
-[sudo apt-get -y upgrade]='Upgrading...'
-[sudo apt-get -y install dnsutils bc toilet]='Installing chronomoter tools...'
-[sudo apt-get -y install dnsmasq]='Installing a DNS server...'
-[sudo apt-get -y install lighttpd php5-common php5-cgi php5]='Instaling a Web server and PHP...'
-[sudo mkdir /var/www/html]='Making an HTML folder...'
-[sudo chown www-data:www-data /var/www/html]='Setting permissions for the Web server...'
-[sudo chmod 775 /var/www/html]='Setting permissions for the Web server...'
-[sudo usermod -a -G www-data pi]='Setting permissions for the Web server...'
-[sudo service dnsmasq stop]='Stopping dnsmasq to modify it...'
-[sudo service lighttpd stop]='Stopping lighttpd to modify it...'
-[sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig]='Backing up the dnsmasq config file...'
-[sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig]='Backing up the lighttpd config file...'
-[sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig]='Backing up the default Web page...'
-[sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf]='Installing the dnsmasq config file...'
-[sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf]='Installing the lighttpd config file...'
-[sudo lighty-enable-mod fastcgi fastcgi-php]='Enabling PHP...'
-[sudo mkdir /var/www/html/pihole]='Making a directory for the Web interface...'
-[sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html]='Installing a blank HTML page to take place of ads...'
-[sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip]='Downloading the Pi-hole dashboard...'
-[sudo unzip /var/www/master.zip -d /var/www/html/]='Unpacking the dashboard...'
-[sudo mv /var/www/html/AdminLTE-master /var/www/html/admin]='Renaming the dashboard...'
-[sudo rm /var/www/master.zip 2>/dev/null]='Cleaning up the dashboard temp files...'
-[sudo touch /var/log/pihole.log]='Creating a log file for the Pi-hole...'
-[sudo chmod 644 /var/log/pihole.log]='Making sure the log is readable...'
-[sudo chown dnsmasq:root /var/log/pihole.log]='Letting dnsmasq see the log file so stats can be displayed...'
-[sudo curl -o /usr/local/bin/gravity.sh "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh"]='Initating sub-space transport...'
-[sudo curl -o /usr/local/bin/chronometer.sh "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh"]='Initating sub-space transport...'
-[sudo chmod 755 /usr/local/bin/gravity.sh]='Making the scripts executable...'
-[sudo chmod 755 /usr/local/bin/chronometer.sh]='Making the scripts executable...'
-[sudo /usr/local/bin/gravity.sh]='Entering the event horizion...'
-[sudo reboot]='Restarting...')
+# This is pretty ugly, but it works to present a nice front-end
+# http://stackoverflow.com/questions/29161323/how-to-keep-associative-array-order-in-bash
+# Maybe it would be better to just show the command output instead of the progress bar
+declare -A commands;      declare -a echoes;
+commands["Updating"]="sudo apt-get update"; echoes+=( "Updating" )
+commands["Upgrading"]="sudo apt-get -y upgrade"; echoes+=( "Upgrading" )
+commands["Installing chronomoter tools"]="sudo apt-get -y install dnsutils bc toilet"; echoes+=( "Installing chronomoter tools" )
+commands["Installing a DNS server"]="sudo apt-get -y install dnsmasq"; echoes+=( "Installing a DNS server" )
+commands["Instaling a Web server and PHP"]="sudo apt-get -y install lighttpd php5-common php5-cgi php5"; echoes+=( "Instaling a Web server and PHP" )
+commands["Making an HTML folder"]="sudo mkdir /var/www/html"; echoes+=( "Making an HTML folder" )
+commands["chowning the Web server"]="sudo chown www-data:www-data /var/www/html"; echoes+=( "chowning the Web server" )
+commands["chmodding the Web server"]="sudo chmod 775 /var/www/html"; echoes+=( "chmodding the Web server" )
+commands["Giving pi access to the Web server"]="sudo usermod -a -G www-data pi"; echoes+=( "Giving pi access to the Web server" )
+commands["Stopping dnsmasq to modify it"]="sudo service dnsmasq stop"; echoes+=( "Stopping dnsmasq to modify it" )
+commands["Stopping lighttpd to modify it"]="sudo service lighttpd stop"; echoes+=( "Stopping lighttpd to modify it" )
+commands["Backing up the dnsmasq config file"]="sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig"; echoes+=( "Backing up the dnsmasq config file" )
+commands["Backing up the lighttpd config file"]="sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig"; echoes+=( "Backing up the lighttpd config file" )
+commands["Backing up the default Web page"]="sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig"; echoes+=( "Backing up the default Web page" )
+commands["Installing the dnsmasq config file"]="sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf"; echoes+=( "Installing the dnsmasq config file" )
+commands["Installing the lighttpd config file"]="sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf"; echoes+=( "Installing the lighttpd config file" )
+commands["Enabling PHP"]="sudo lighty-enable-mod fastcgi fastcgi-php"; echoes+=( "Enabling PHP" )
+commands["Making a directory for the Web interface"]="sudo mkdir /var/www/html/pihole"; echoes+=( "Making a directory for the Web interface" )
+commands["Installing a blank HTML page to take place of ads"]="sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html"; echoes+=( "Installing a blank HTML page to take place of ads" )
+commands["Downloading the Pi-hole dashboard"]="sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip"; echoes+=( "Downloading the Pi-hole dashboard" )
+commands["Unpacking the dashboard"]="sudo unzip /var/www/master.zip -d /var/www/html/"; echoes+=( "Unpacking the dashboard" )
+commands["Renaming the dashboard"]="sudo mv /var/www/html/AdminLTE-master /var/www/html/admin"; echoes+=( "Renaming the dashboard" )
+commands["Cleaning up the dashboard temp files"]="sudo rm /var/www/master.zip 2>/dev/null"; echoes+=( "Cleaning up the dashboard temp files" )
+commands["Creating a log file for the Pi-hole"]="sudo touch /var/log/pihole.log"; echoes+=( "Creating a log file for the Pi-hole" )
+commands["chmodding the log file"]="sudo chmod 644 /var/log/pihole.log"; echoes+=( "chmodding the log file" )
+commands["chowning the log file so stats can be displayed"]="sudo chown dnsmasq:root /var/log/pihole.log"; echoes+=( "chowning the log file so stats can be displayed" )
+commands["Initating sub-space transport of gravity"]="sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh"; echoes+=( "Initating sub-space transport of gravity" )
+commands["Initating sub-space transport of chronometer"]="sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh"; echoes+=( "Initating sub-space transport of chronometer" )
+commands["chmodding gravity"]="sudo chmod 755 /usr/local/bin/gravity.sh"; echoes+=( "chmodding gravity" )
+commands["chmodding the chronometer"]="sudo chmod 755 /usr/local/bin/chronometer.sh"; echoes+=( "chmodding the chronometer" )
+commands["Entering the event horizion"]="sudo /usr/local/bin/gravity.sh"; echoes+=( "Entering the event horizion" )
+commands["Rebooting"]="sudo reboot"; echoes+=( "Rebooting" )
 
 # Everything in the parentheses is part of displaying the progress bar
 (
 # Get total number of commands to be run from the array
-n=${#cmdsAndEchoes[*]};
-
+n=${#commands[*]};
 # Set counter to increase every time a loop completes
 i=0
 
-# For each key in the array
-for key in "${!cmdsAndEchoes[@]}"
+# For each item in the array
+for k in "${!echoes[@]}"
 do
 
 # Calculate the overall progress
@@ -181,11 +183,13 @@ percent=$(( 100*(++i)/n ))
 cat <<EOF
 XXX
 $percent
-${cmdsAndEchoes[$key]}
+Step $i of $n: ${echoes[$k]}
 XXX
 EOF
 # Execute the command in the background (hidden from the user, not actually a background process)
-$key
+#${echoes[$k]}
+${commands[${echoes[$k]}]}
+sleep 1
 done
 # As the loop is progressing, the output is sent to whiptail to be displayed to the user
 ) |

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -24,7 +24,6 @@ columns=$(stty -a | tr \; \\012 | egrep 'columns' | cut -d' ' -f3)
 r=$(( rows / 2 ))
 c=$(( columns / 2 ))
 
-# Get the current network settings
 IPv4addr=$(ip -4 addr show | awk '{match($0,/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/); ip = substr($0,RSTART,RLENGTH); print ip}' | sed '/^\s*$/d' | grep -v "127.0.0.1")
 IPv4mask=$(ifconfig | awk -F':' '/inet addr/ && !/127.0.0.1/ {print $4}')
 IPv4gw=$(ip route show | awk '/default\ via/ {print $3}')
@@ -164,6 +163,8 @@ commands["Backing up the lighttpd config file"]="sudo mv /etc/lighttpd/lighttpd.
 commands["Backing up the default Web page"]="sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig"; echoes+=( "Backing up the default Web page" )
 commands["Installing the dnsmasq config file"]="sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf"; echoes+=( "Installing the dnsmasq config file" )
 commands["Installing the lighttpd config file"]="sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf"; echoes+=( "Installing the lighttpd config file" )
+commands["Initating auto-pilot"]="sudo mv /etc/crontab /etc/crontab.orig"; echoes+=( "Initiating auto-pilot" )
+commands["Engaging auto-pilot"]="curl -o /etc/crontab https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron"; echoes+=( "Engaging auto-pilot" )
 commands["Enabling PHP"]="sudo lighty-enable-mod fastcgi fastcgi-php"; echoes+=( "Enabling PHP" )
 commands["Making a directory for the Web interface"]="sudo mkdir /var/www/html/pihole"; echoes+=( "Making a directory for the Web interface" )
 commands["Installing a blank HTML page to take place of ads"]="sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html"; echoes+=( "Installing a blank HTML page to take place of ads" )
@@ -182,7 +183,7 @@ commands["Entering the event horizion"]="sudo /usr/local/bin/gravity.sh"; echoes
 commands["Rebooting"]="sudo service networking restart"; echoes+=( "Restarting networking..." )
 
 # Everything in the parentheses is part of displaying the progress bar
-(
+#(
 # Get total number of commands to be run from the array
 n=${#commands[*]};
 # Set counter to increase every time a loop completes
@@ -205,10 +206,10 @@ XXX
 EOF
 
 # Execute the command in the background (hidden from the user, not actually a background process)
-${commands[${echoes[$k]}]} > $tmpLog 2>&1
+${commands[${echoes[$k]}]} | tee $tmpLog
+clear
 done
 sudo mv $tmpLog $instalLogLoc$instalLogLoc
 
 # As the loop is progressing, the output is sent to whiptail to be displayed to the user
-) |
-whiptail --title "Opening your Pi-hole..." --gauge "Please wait..." $r $c 0
+#) |whiptail --title "Opening your Pi-hole..." --gauge "Please wait..." $r $c 0

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -10,6 +10,8 @@
 # curl -L install.pi-hole.net | bash
 
 ######## VARIABLES #########
+instalLogLoc=/etc/pihole/install.log
+
 # Get the screen size in case we need a full-screen message and so we can display a dialog that is sized nicely
 screenSize=$(stty -a | tr \; \\012 | egrep 'rows|columns' | cut '-d ' -f3)
 
@@ -202,7 +204,7 @@ XXX
 EOF
 
 # Execute the command in the background (hidden from the user, not actually a background process)
-${commands[${echoes[$k]}]} > /dev/null 2>&1
+${commands[${echoes[$k]}]} > $instalLogLoc 2>&1
 done
 
 # As the loop is progressing, the output is sent to whiptail to be displayed to the user

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -10,6 +10,7 @@
 # curl -L install.pi-hole.net | bash
 
 ######## VARIABLES #########
+tmpLog=/tmp/pihole-install.log
 instalLogLoc=/etc/pihole/install.log
 
 # Get the screen size in case we need a full-screen message and so we can display a dialog that is sized nicely
@@ -206,6 +207,7 @@ EOF
 # Execute the command in the background (hidden from the user, not actually a background process)
 ${commands[${echoes[$k]}]} > $instalLogLoc 2>&1
 done
+sudo mv $tmpLog $instalLogLoc$instalLogLoc
 
 # As the loop is progressing, the output is sent to whiptail to be displayed to the user
 ) |

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -224,7 +224,7 @@ sudo rm /var/www/master.zip 2>/dev/null
 sudo touch /var/log/pihole.log
 sudo chmod 644 /var/log/pihole.log
 sudo chown dnsmasq:root /var/log/pihole.log
-sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/installation/gravity.sh
+sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
 sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
 sudo curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
 sudo curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -179,7 +179,7 @@ commands["Initating sub-space transport of chronometer"]="sudo curl -o /usr/loca
 commands["chmodding gravity"]="sudo chmod 755 /usr/local/bin/gravity.sh"; echoes+=( "chmodding gravity" )
 commands["chmodding the chronometer"]="sudo chmod 755 /usr/local/bin/chronometer.sh"; echoes+=( "chmodding the chronometer" )
 commands["Entering the event horizion"]="sudo /usr/local/bin/gravity.sh"; echoes+=( "Entering the event horizion" )
-commands["Rebooting"]="sudo reboot"; echoes+=( "Rebooting" )
+commands["Rebooting"]="sudo service networking restart"; echoes+=( "Restarting networking..." )
 
 # Everything in the parentheses is part of displaying the progress bar
 (

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -189,9 +189,9 @@ sudo mv $tmpLog $instalLogLoc
 
 whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using this IP: $IPv4addr.
 
-The networking service will restart after you close this dialog.  If you are using SSH, you may need to reconnect." $r $c
+Your Pi will restart when you close this dialog.  If you are using SSH, reconnect using the IP address above.
 
-# Start the services and restart networking
-sudo service dnsmasq start
-sudo service lighttpd start
-sudo ifdown eth0;sudo ifup eth0
+The install log is in /etc/phole." $r $c
+
+
+sudo reboot

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1,29 +1,37 @@
 #!/bin/bash
-# Pi-hole automated install
-# Raspberry Pi Ad-blocker
+# Pi-hole: A black hole for Internet advertisements
+# by Jacob Salmela
+# Network-wide ad blocking via your Raspberry Pi
 #
-# Install with this command (from the Pi):
+# pi-hole.net/donate
 #
-# curl -s "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/automated%20install/basic-install.sh" | bash
+# Install with this command (from your Pi):
 #
-# Or run the commands below in order
+# curl -L install.pi-hole.net | bash
 
-clear
-echo "  _____ _        _           _      "
-echo " |  __ (_)      | |         | |     "
-echo " | |__) |   __  | |__   ___ | | ___ "
-echo " |  ___/ | |__| | '_ \ / _ \| |/ _ \ "
-echo " | |   | |      | | | | (_) | |  __/ "
-echo " |_|   |_|      |_| |_|\___/|_|\___| "
-echo "                                    "
-echo "      Raspberry Pi Ad-blocker       "
-echo "									  "
-echo "Set a static IP before running this!"
-echo "			             			  "
-echo "	    Press Enter when ready        "
-echo "									  "
-read
+######## VARIABLES #########
+# Get the screen size in case we need a full-screen message and so we can display a dialog that is sized nicely
+screenSize=$(stty -a | tr \; \\012 | egrep 'rows|columns' | cut '-d ' -f3)
 
+# Find the rows and columns
+rows=$(stty -a | tr \; \\012 | egrep 'rows' | cut -d' ' -f3)
+columns=$(stty -a | tr \; \\012 | egrep 'columns' | cut -d' ' -f3)
+
+# Divide by two so the dialogs take up half of the screen, which looks nice.
+r=$(( rows / 2 ))
+c=$(( columns / 2 ))
+
+# Get the current network settings
+IPv4addr=$(ip -4 addr show | awk '{match($0,/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/); ip = substr($0,RSTART,RLENGTH); print ip}' | sed '/^\s*$/d' | grep -v "127.0.0.1")
+IPv4mask=$(ifconfig | awk -F':' '/inet addr/ && !/127.0.0.1/ {print $4}')
+IPv4gw=$(ip route show | awk '/default\ via/ {print $3}')
+
+# IPv6 support to be added later
+IPv6addr=$(ip addr show | awk '/scope\ global/ && /ff:fe/ {print $2}' | cut -d'/' -f1)
+
+####### FUCNTIONS ##########
+backupLegacyPihole()
+{
 if [[ -f /etc/dnsmasq.d/adList.conf ]];then
 	echo "Original Pi-hole detected.  Initiating sub space transport..."
 	sudo mkdir -p /etc/pihole/original/
@@ -36,58 +44,149 @@ if [[ -f /etc/dnsmasq.d/adList.conf ]];then
 else
 	:
 fi
+}
 
-echo "Updating the Pi..."
-sudo apt-get update
-sudo apt-get -y upgrade
+######## SCRIPT ############
+# Just back up the original Pi-hole right away since it won't take long and it gets it out of the way
+backupLegacyPihole
 
-echo "Installing tools..."
-sudo apt-get -y install dnsutils
-sudo apt-get -y install bc
-sudo apt-get -y install toilet
+# Display the welcome dialog
+whiptail --msgbox --backtitle "Welcome..." --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
 
-echo "Installing DNS..."
-sudo apt-get -y install dnsmasq
-sudo update-rc.d dnsmasq enable
+# Explain the need for a static address
+whiptail --msgbox --backtitle "Initating network interface..." --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.
 
-echo "Installing a Web server"
-sudo apt-get -y install lighttpd php5-common php5-cgi php5
-sudo mkdir /var/www/html
-sudo chown www-data:www-data /var/www/html
-sudo chmod 775 /var/www/html
-sudo usermod -a -G www-data pi
+In the next section, you can choose to use your current network settings (DHCP) or to manually edit them." $r $c
 
-echo "Stopping services to modify them..."
-sudo service dnsmasq stop
-sudo service lighttpd stop
+# Ask if the user wannts to use DHCP settings as their static IP
+if (whiptail --title "Static IP Address" --yesno "Do you want to use your current network settings as a static address?
 
-echo "Backing up original config files and downloading Pi-hole ones..."
-sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
-sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
-sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
-sudo curl -o /etc/dnsmasq.conf "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf"
-sudo curl -o /etc/lighttpd/lighttpd.conf "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf"
-sudo lighty-enable-mod fastcgi fastcgi-php
-sudo mkdir /var/www/html/pihole
-sudo curl -o /var/www/html/pihole/index.html "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html"
+							IP address:    $IPv4addr
+							Subnet mask:   $IPv4mask
+							Gateway:       $IPv4gw" $r $c) then
+	# If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
+	whiptail --msgbox --backtitle "IP information..." --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
 
-echo "Installing the Web interface..."
-sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip
-sudo unzip /var/www/master.zip -d /var/www/html/
-sudo mv /var/www/html/AdminLTE-master /var/www/html/admin
-sudo rm /var/www/master.zip 2>/dev/null
-sudo touch /var/log/pihole.log
-sudo chmod 644 /var/log/pihole.log
-sudo chown dnsmasq:root /var/log/pihole.log
+If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
 
-echo "Locating the Pi-hole..."
-sudo curl -o /usr/local/bin/gravity.sh "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh"
-sudo curl -o /usr/local/bin/chronometer.sh "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh"
-sudo chmod 755 /usr/local/bin/gravity.sh
-sudo chmod 755 /usr/local/bin/chronometer.sh
+It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address." $r $c
+	# Nothing else to do since the variables are already set above
+else
+	# Otherwise, we need to ask the user to input their desired settings.
+	# Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
+	# Start a loop to let the user enter their information with the chance to go back and edit it if necessary
+	until [[ $ipSettingsCorrect = True ]]
+	do
+	# Ask for the IPv4 address
+	IPv4addr=$(whiptail --backtitle "Calibrating network interface..." --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
+	if [[ $? = 0 ]];then
+    	echo "Your static IPv4 address:    $IPv4addr"
+		# Ask for the subnet mask
+		IPv4mask=$(whiptail --backtitle "Calibrating network interface..." --title "IPv4 netmask" --inputbox "Enter your desired IPv4 subnet mask" $r $c $IPv4mask 3>&1 1>&2 2>&3)
+		if [[ $? = 0 ]];then
+				echo "Your static IPv4 netmask:    $IPv4mask"
+				# Ask for the gateway
+				IPv4gw=$(whiptail --backtitle "Calibrating network interface..." --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
+				if [[ $? = 0 ]];then
+						echo "Your static IPv4 gateway:    $IPv4gw"
+						# Give the user a chance to review their settings before moving on
+						if (whiptail --title "Static IP Address" --yesno "Are these settings correct?
+							IP address:    $IPv4addr
+							Subnet mask:   $IPv4mask
+							Gateway:       $IPv4gw" $r $c)then
+							# If the settings are correct, then we need to set the piholeIP
+							# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script
+							echo $IPv4addr > /tmp/piholeIP
+							# After that's done, the loop ends and we move on
+							ipSettingsCorrect=True
 
-echo "Entering the event horizon..."
-sudo /usr/local/bin/gravity.sh
+						else
+							# If the settings are wrong, the loop continues
+							ipSettingsCorrect=False
+						fi
+				else
+					# Cancelling gateway settings window
+					ipSettingsCorrect=False
+					echo "User canceled."
+					exit
+				fi
+		else
+			# Cancelling subnet mask settings window
+			ipSettingsCorrect=False
+			echo "User canceled."
+			exit
+		fi
+	else
+		# Cancelling IPv4 settings window
+		ipSettingsCorrect=False
+    	echo "User canceled."
+		exit
+	fi
+	done
+# End the if statement for DHCP vs. static
+fi
 
-echo "Restarting..."
-sudo reboot
+# These are the commands to actually install the Pi-hole
+# Create an associative array so we can display text to the user but run the associated command in the background.
+declare -A cmdsAndEchoes=([sudo apt-get update]='Updating...'
+[sudo apt-get -y upgrade]='Upgrading...'
+[sudo apt-get -y install dnsutils bc toilet]='Installing chronomoter tools...'
+[sudo apt-get -y install dnsmasq]='Installing a DNS server...'
+[sudo apt-get -y install lighttpd php5-common php5-cgi php5]='Instaling a Web server and PHP...'
+[sudo mkdir /var/www/html]='Making an HTML folder...'
+[sudo chown www-data:www-data /var/www/html]='Setting permissions for the Web server...'
+[sudo chmod 775 /var/www/html]='Setting permissions for the Web server...'
+[sudo usermod -a -G www-data pi]='Setting permissions for the Web server...'
+[sudo service dnsmasq stop]='Stopping dnsmasq to modify it...'
+[sudo service lighttpd stop]='Stopping lighttpd to modify it...'
+[sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig]='Backing up the dnsmasq config file...'
+[sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig]='Backing up the lighttpd config file...'
+[sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig]='Backing up the default Web page...'
+[sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf]='Installing the dnsmasq config file...'
+[sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf]='Installing the lighttpd config file...'
+[sudo lighty-enable-mod fastcgi fastcgi-php]='Enabling PHP...'
+[sudo mkdir /var/www/html/pihole]='Making a directory for the Web interface...'
+[sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html]='Installing a blank HTML page to take place of ads...'
+[sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip]='Downloading the Pi-hole dashboard...'
+[sudo unzip /var/www/master.zip -d /var/www/html/]='Unpacking the dashboard...'
+[sudo mv /var/www/html/AdminLTE-master /var/www/html/admin]='Renaming the dashboard...'
+[sudo rm /var/www/master.zip 2>/dev/null]='Cleaning up the dashboard temp files...'
+[sudo touch /var/log/pihole.log]='Creating a log file for the Pi-hole...'
+[sudo chmod 644 /var/log/pihole.log]='Making sure the log is readable...'
+[sudo chown dnsmasq:root /var/log/pihole.log]='Letting dnsmasq see the log file so stats can be displayed...'
+[sudo curl -o /usr/local/bin/gravity.sh "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh"]='Initating sub-space transport...'
+[sudo curl -o /usr/local/bin/chronometer.sh "https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh"]='Initating sub-space transport...'
+[sudo chmod 755 /usr/local/bin/gravity.sh]='Making the scripts executable...'
+[sudo chmod 755 /usr/local/bin/chronometer.sh]='Making the scripts executable...'
+[sudo /usr/local/bin/gravity.sh]='Entering the event horizion...'
+[sudo reboot]='Restarting...')
+
+# Everything in the parentheses is part of displaying the progress bar
+(
+# Get total number of commands to be run from the array
+n=${#cmdsAndEchoes[*]};
+
+# Set counter to increase every time a loop completes
+i=0
+
+# For each key in the array
+for key in "${!cmdsAndEchoes[@]}"
+do
+
+# Calculate the overall progress
+percent=$(( 100*(++i)/n ))
+
+# Update dialog box using the value of each key in the array
+# Show the percentage and the echo messages from the array
+cat <<EOF
+XXX
+$percent
+${cmdsAndEchoes[$key]}
+XXX
+EOF
+# Execute the command in the background (hidden from the user, not actually a background process)
+$key
+done
+# As the loop is progressing, the output is sent to whiptail to be displayed to the user
+) |
+whiptail --title "Opening your Pi-hole..." --gauge "Please wait..." $r $c 0

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -168,7 +168,7 @@ commands["Enabling PHP"]="sudo lighty-enable-mod fastcgi fastcgi-php"; echoes+=(
 commands["Making a directory for the Web interface"]="sudo mkdir /var/www/html/pihole"; echoes+=( "Making a directory for the Web interface" )
 commands["Installing a blank HTML page to take place of ads"]="sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html"; echoes+=( "Installing a blank HTML page to take place of ads" )
 commands["Downloading the Pi-hole dashboard"]="sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip"; echoes+=( "Downloading the Pi-hole dashboard" )
-commands["Unpacking the dashboard"]="sudo unzip /var/www/master.zip -d /var/www/html/"; echoes+=( "Unpacking the dashboard" )
+commands["Unpacking the dashboard"]="sudo unzip -o /var/www/master.zip -d /var/www/html/"; echoes+=( "Unpacking the dashboard" )
 commands["Renaming the dashboard"]="sudo mv /var/www/html/AdminLTE-master /var/www/html/admin"; echoes+=( "Renaming the dashboard" )
 commands["Cleaning up the dashboard temp files"]="sudo rm /var/www/master.zip 2>/dev/null"; echoes+=( "Cleaning up the dashboard temp files" )
 commands["Creating a log file for the Pi-hole"]="sudo touch /var/log/pihole.log"; echoes+=( "Creating a log file for the Pi-hole" )

--- a/gravity.sh
+++ b/gravity.sh
@@ -143,7 +143,7 @@ function gravity_advanced()
 	echo "** $numberOf unique domains trapped in the event horizon."
 	# Format domain list as "192.168.x.x domain.com"
 	echo "** Formatting domains into a HOSTS file..."
-	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP"'" $0}' > $origin/$accretionDisc
+	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP"' " $0}' > $origin/$accretionDisc
 	# Copy the file over as /etc/pihole/gravity.list so dnsmasq can use it
 	sudo cp $origin/$accretionDisc $adList
 	kill -HUP $(pidof dnsmasq)

--- a/gravity.sh
+++ b/gravity.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # http://pi-hole.net
-# Compiles a list of ad-serving domains by downloading them from multiple sources 
-
-# This script should only be run after you have a static IP address set on the Pi
-piholeIP=$(hostname -I)
+# Compiles a list of ad-serving domains by downloading them from multiple sources
+piholeIPfile=/tmp/piholeIP
+if [[ -f $piholeIPfile ]];then
+    # If the file exists, it means it was exported from the installation script and we should use that value instead of detecting it in this script
+    piholeIP=$(cat $piholeIPfile)
+    rm $piholeIPfile
+else
+    # Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
+    piholeIP=$(ip -4 addr show | awk '{match($0,/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/); ip = substr($0,RSTART,RLENGTH); print ip}' | sed '/^\s*$/d' | grep -v "127.0.0.1")
+fi
 
 # Ad-list sources--one per line in single quotes
+# The mahakala source is commented out due to many users having issues with it blocking legitimate domains.  Uncomment at your own risk
 sources=('https://adaway.org/hosts.txt'
 'http://adblock.gjtech.net/?format=unix-hosts'
 #'http://adblock.mahakala.is/'
@@ -58,7 +65,7 @@ function createSwapFile()
 	sudo dphys-swapfile setup
 	sudo dphys-swapfile swapon
 	}
-	
+
 
 if [[ -n "$noSwap" ]]; then
     # if $noSwap is set, don't do anything
@@ -83,20 +90,20 @@ do
 	url=${sources[$i]}
 	# Get just the domain from the URL
 	domain=$(echo "$url" | cut -d'/' -f3)
-	
+
 	# Save the file as list.#.domain
 	saveLocation=$origin/list.$i.$domain.$justDomainsExtension
-	
+
 		echo -n "Getting $domain list... "
 	# Use a case statement to download lists that need special cURL commands to complete properly
 	case "$domain" in
 		"adblock.mahakala.is") data=$(curl -s -A 'Mozilla/5.0 (X11; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0' -e http://forum.xda-developers.com/ -z $saveLocation $url);;
-		
+
 		"pgl.yoyo.org") data=$(curl -s -d mimetype=plaintext -d hostformat=hosts -z $saveLocation $url);;
 
 		*) data=$(curl -s -z $saveLocation -A "Mozilla/10.0" $url);;
 	esac
-	
+
 	if [[ -n "$data" ]];then
 		# Remove comments and print only the domain name
 		# Most of the lists downloaded are already in hosts file format but the spacing/formating is not contigious
@@ -127,7 +134,7 @@ function gravity_advanced()
 ###########################
 	{
 	numberOf=$(cat $origin/$andLight | sed '/^\s*$/d' | wc -l)
-	echo "** $numberOf domains being pulled in by gravity..."	
+	echo "** $numberOf domains being pulled in by gravity..."
 	# Remove carriage returns and preceding whitespace
 	cat $origin/$andLight | sed $'s/\r$//' | sed '/^\s*$/d' > $origin/$supernova
 	# Sort and remove duplicates
@@ -141,7 +148,7 @@ function gravity_advanced()
 	sudo cp $origin/$accretionDisc $adList
 	kill -HUP $(pidof dnsmasq)
 	}
-	
+
 # Whitelist (if applicable) then remove duplicates and format for dnsmasq
 if [[ -f $whitelist ]];then
 	# Remove whitelist entries


### PR DESCRIPTION
In an effort to make the Pi-hole easier to install, I have created an installer that leads the user through the setup.  Users will no longer need to set a static IP address manually before running the installer.  This simplifies the process:
1. Install Raspbian onto your SD card
2. Run this command: `curl -L install.pi-hole.net | bash`
3. Follow the dialogs to finish the installation

This enhancement will also pave the way for IPv6 support as well as the historical stats database.

![pi-hole-instal2](https://cloud.githubusercontent.com/assets/3843505/11166746/2a55096a-8b09-11e5-9712-3413c6a3c181.png)

![pi-hole-instal-ip2](https://cloud.githubusercontent.com/assets/3843505/11166744/19eac736-8b09-11e5-89b8-860f0d4e0f01.png)

![pi-hole-instal-ip-verify](https://cloud.githubusercontent.com/assets/3843505/11166748/5b641ad2-8b09-11e5-8479-bdc2f85e2d36.png)
 