### PR TITLE
Add Makefile for portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+DESTDIR =
+PREFIX  = /usr/local
+BINDIR  = $(PREFIX)/bin
+
+install:
+        install -Dm755 gravity.sh $(DESTDIR)$(BINDIR)/gravity.sh
+        install -Dm755 ./advanced/Scripts/chronometer.sh $(DESTDIR)$(BINDIR)/chronometer.sh
+        install -Dm755 ./advanced/Scripts/whitelist.sh $(DESTDIR)$(BINDIR)/whitelist.sh
+        install -Dm755 ./advanced/Scripts/piholeLogFlush.sh $(DESTDIR)$(BINDIR)/piholeLogFlush.sh
+
+.PHONY : install


### PR DESCRIPTION
This will allow for package portability to Debian and other platforms. Allows for differing FHS standards, (/usr/bin on Deb vs /usr/local/bin on others.)