### PR TITLE
Use last IP for selected interface

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -25,10 +25,9 @@ r=$(( rows / 2 ))
 c=$(( columns / 2 ))
 
 # Find IP used to route to outside world
-IPv4info=$(ip route get 8.8.8.8)
-IPv4dev=$(echo $IPv4info| awk '{print $5}')
-IPv4addr=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}')
-IPv4gw=$(echo $IPv4info | awk '{print $3}')
+IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
+IPv4addr=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | awk 'END {print}')
+IPv4gw=$(ip route get 8.8.8.8 | awk '{print $3}')
 
 # IPv6 support to be added later
 #IPv6eui64=$(ip addr show | awk '/scope\ global/ && /ff:fe/ {print $2}' | cut -d'/' -f1)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -34,7 +34,7 @@ IPv4gw=$(echo $IPv4info | awk '{print $3}')
 #IPv6eui64=$(ip addr show | awk '/scope\ global/ && /ff:fe/ {print $2}' | cut -d'/' -f1)
 #IPv6linkLocal=$(ip addr show | awk '/inet/ && /scope\ link/ && /fe80/ {print $2}' | cut -d'/' -f1)
 
-availableInterfaces=$(ip link show | awk -F' ' '/[0-9]: [a-z]/ {print $2}' | grep -v "lo" | cut -d':' -f1)
+availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -f1)
 dhcpcdFile=/etc/dhcpcd.conf
 
 ####### FUCNTIONS ##########
@@ -82,6 +82,7 @@ for desiredInterface in $chooseInterfaceOptions
 do
 	piholeInterface=$desiredInterface
 	echo "Using interface: $piholeInterface"
+	echo ${piholeInterface} > /tmp/piholeINT
 done
 }
 
@@ -92,7 +93,6 @@ cmd=(whiptail --separate-output --checklist "Select Protocols" $r $c 2)
 options=(IPv4 "Block ads over IPv4" on
          IPv6 "Block ads over IPv4" off)
 choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-clear
 for choice in $choices
 do
     case $choice in
@@ -171,56 +171,91 @@ done
 fi
 }
 
-
-setStaticIPv4()
-{
-# Append these lines to /etc/dhcpcd.conf to enable a static IP
+setDHCPCD(){
+# Append these lines to dhcpcd.conf to enable a static IP
 echo "interface $piholeInterface
 static ip_address=$IPv4addr
 static routers=$IPv4gw
 static domain_name_servers=$IPv4gw" | sudo tee -a $dhcpcdFile >/dev/null
-sudo ip addr replace dev $piholeInterface $IPv4addr
 }
 
-installPihole()
-{
+setStaticIPv4(){
+if grep -q $IPv4addr $dhcpcdFile; then
+	# address already set, noop
+	:
+else
+	setDHCPCD
+	sudo ip addr replace dev $piholeInterface $IPv4addr
+	echo "Setting IP to $IPv4addr.  You may need to restart after the install is complete."
+fi
+}
+
+installScripts(){
+sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
+sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
+sudo curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
+sudo curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh
+sudo chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,piholeLogFlush}.sh
+}
+
+installConfigs(){
+sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
+sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
+sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
+sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
+sudo sed -i "s/@INT@/$piholeInterface/" /etc/dnsmasq.conf
+}
+
+stopServices(){
+sudo service dnsmasq stop || true
+sudo service lighttpd stop || true
+}
+
+installDependencies(){
 sudo apt-get update
 sudo apt-get -y upgrade
 sudo apt-get -y install dnsutils bc toilet
 sudo apt-get -y install dnsmasq
 sudo apt-get -y install lighttpd php5-common php5-cgi php5
-sudo mkdir /var/www/html
-sudo chown www-data:www-data /var/www/html
-sudo chmod 775 /var/www/html
-sudo usermod -a -G www-data pi
-sudo service dnsmasq stop
-sudo service lighttpd stop
-sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
-sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
-sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
-sudo mv /etc/crontab /etc/crontab.orig
-sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
-sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
-sudo mv /etc/crontab /etc/crontab.orig
-sudo curl -o /etc/crontab https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
-sudo lighty-enable-mod fastcgi fastcgi-php
-sudo mkdir /var/www/html/pihole
-sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html
+}
+
+installWebAdmin(){
 sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip
-sudo unzip -o /var/www/master.zip -d /var/www/html/
+sudo unzip -oq /var/www/master.zip -d /var/www/html/
 sudo mv /var/www/html/AdminLTE-master /var/www/html/admin
 sudo rm /var/www/master.zip 2>/dev/null
+}
+
+installPiholeWeb(){
+sudo mkdir /var/www/html/pihole
+sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
+sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html
+}
+
+installCron(){
+sudo mv /etc/crontab /etc/crontab.orig
+sudo curl -o /etc/crontab https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
+}
+
+installPiLog(){
 sudo touch /var/log/pihole.log
 sudo chmod 644 /var/log/pihole.log
 sudo chown dnsmasq:root /var/log/pihole.log
-sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
-sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
-sudo curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
-sudo curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh
-sudo chmod 755 /usr/local/bin/gravity.sh
-sudo chmod 755 /usr/local/bin/chronometer.sh
-sudo chmod 755 /usr/local/bin/whitelist.sh
-sudo chmod 755 /usr/local/bin/piholeLogFlush.sh
+}
+installPihole()
+{
+installDependencies
+stopServices
+sudo chown www-data:www-data /var/www/html
+sudo chmod 775 /var/www/html
+sudo usermod -a -G www-data pi
+sudo lighty-enable-mod fastcgi fastcgi-php
+installScripts
+installConfigs
+installWebAdmin
+installPiholeWeb
+installCron
+installPiLog
 sudo /usr/local/bin/gravity.sh
 }
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -13,7 +13,7 @@ if [[ -f $piholeIPfile ]];then
 else
     # Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
 	IPv4dev=$(ip route get 8.8.8.8 | awk '{print $5}')
-	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}') | sed -n '$p'
+	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}') | awk 'END {print}')
 	piholeIP=${piholeIPCIDR%/*}
 fi
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -13,7 +13,7 @@ if [[ -f $piholeIPfile ]];then
 else
     # Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
 	IPv4dev=$(ip route get 8.8.8.8 | awk '{print $5}')
-	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}')
+	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}') | sed -n '$p'
 	piholeIP=${piholeIPCIDR%/*}
 fi
 


### PR DESCRIPTION
Fixes bug #112 . Pulls the last IP for selected interface which should be the IP for the interface if the user added a custom IP in the basic install. Interface can have multiple IP's without issues.