### PR TITLE
Bugfix - Gravity.sh interface check

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Flushes /var/log/pihole.log
+truncate -s 0 /var/log/pihole.log

--- a/gravity.sh
+++ b/gravity.sh
@@ -137,7 +137,7 @@ function gravity_advanced()
 	echo "** $numberOf unique domains trapped in the event horizon."
 	# Format domain list as "192.168.x.x domain.com"
 	echo "** Formatting domains into a HOSTS file..."
-	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIP"'" $0}' > $origin/$accretionDisc
+	cat $origin/$eventHorizon | awk '{sub(/\r$/,""); print "'"$piholeIPv4 "'" $0"\n""'"$piholeIPv6 "'" $0}' > $origin/$accretionDisc
 	# Copy the file over as /etc/pihole/gravity.list so dnsmasq can use it
 	sudo cp $origin/$accretionDisc $adList
 	kill -HUP $(pidof dnsmasq)

--- a/gravity.sh
+++ b/gravity.sh
@@ -82,7 +82,6 @@ do
 		heisenbergCompensator="-z $saveLocation"
 	fi
 	CMD="$cmd -s $heisenbergCompensator -A '$agent' $url > $patternBuffer"
-	echo "** Engaging pattern transference..."
 	$cmd -s $heisenbergCompensator -A "$agent" $url > $patternBuffer
 
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -12,7 +12,7 @@ if [[ -f $piholeIPfile ]];then
     rm $piholeIPfile
 else
     # Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
-	IPv4dev=$(ip route get 8.8.8.8 | awk '{print $5}')
+	IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
 	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}') | awk 'END {print}')
 	piholeIP=${piholeIPCIDR%/*}
 fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -9,7 +9,7 @@ piholeIP=$(hostname -I)
 sources=('https://adaway.org/hosts.txt'
 'http://adblock.gjtech.net/?format=unix-hosts'
 #'http://adblock.mahakala.is/'
-'http://hosts-file.net/.%5Cad_servers.txt'
+'http://hosts-file.net/ad_servers.txt'
 'http://www.malwaredomainlist.com/hostslist/hosts.txt'
 'http://pgl.yoyo.org/adservers/serverlist.php?'
 'http://someonewhocares.org/hosts/hosts'

--- a/gravity.sh
+++ b/gravity.sh
@@ -75,8 +75,7 @@ do
 		*) cmd="curl"
 	esac
 
-    echo "Narrowing the annular confinment beam..."
-    # Create a tmp file so we don't have to store the (long!) lists in RAM
+	# tmp file, so we don't have to store the (long!) lists in RAM
 	patternBuffer=$(mktemp)
 	heisenbergCompensator=""
 	if [[ -r $saveLocation ]]; then

--- a/gravity.sh
+++ b/gravity.sh
@@ -13,7 +13,7 @@ if [[ -f $piholeIPfile ]];then
 else
     # Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
 	IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}') | awk 'END {print}')
+	piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | awk 'END {print}')
 	piholeIP=${piholeIPCIDR%/*}
 fi
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -75,7 +75,8 @@ do
 		*) cmd="curl"
 	esac
 
-	# tmp file, so we don't have to store the (long!) lists in RAM
+    echo "Narrowing the annular confinment beam..."
+    # Create a tmp file so we don't have to store the (long!) lists in RAM
 	patternBuffer=$(mktemp)
 	heisenbergCompensator=""
 	if [[ -r $saveLocation ]]; then

--- a/gravity.sh
+++ b/gravity.sh
@@ -76,9 +76,9 @@ do
 	esac
 
 	# tmp file, so we don't have to store the (long!) lists in RAM
-	patternBuffer=`mktemp`
+	patternBuffer=$(mktemp)
 	heisenbergCompensator=""
-	if [ -r $saveLocation ]; then
+	if [[ -r $saveLocation ]]; then
 		heisenbergCompensator="-z $saveLocation"
 	fi
 	CMD="$cmd -s $heisenbergCompensator -A '$agent' $url > $patternBuffer"
@@ -97,7 +97,7 @@ do
 		echo "Skipping pattern because transporter logic detected no changes..."
 	fi
 
-	# cleanup
+	# Cleanup
 	rm -f $patternBuffer
 done
 


### PR DESCRIPTION
Fixes #114. Finds the interface based off of keywork `dev` instead of awk'ing a specific location. Allows for other platforms besides Raspbian. 