### PR TITLE
Update gravity.sh

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -240,7 +240,7 @@ function gravity_advanced() {
 
 	gravity_unique
 
-	sudo kill -s -HUP $(pidof dnsmasq)
+	sudo kill -HUP $(pidof dnsmasq)
 }
 
 gravity_collapse


### PR DESCRIPTION
The kill will not work with '-s', resulting in no-reload of updated hosts file.
