### PR TITLE
installer - only select first (probably default) interface in list instead of all

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -74,9 +74,16 @@ chooseInterface()
 {
 # Turn the available interfaces into an array so it can be used with a whiptail dialog
 interfacesArray=()
+firstloop=1
+
 while read -r line
 do
-interfacesArray+=("$line" "available" "ON")
+mode="OFF"
+if [[ $firstloop -eq 1 ]]; then
+  firstloop=0
+  mode="ON"
+fi
+interfacesArray+=("$line" "available" "$mode")
 done <<< "$availableInterfaces"
 
 # Find out how many interfaces are available to choose from


### PR DESCRIPTION
For https://github.com/jacobsalmela/pi-hole/issues/138

99% sure that this works in general. Works for me, but could do with being tested on a few other devices just to be safe. 