### PR TITLE
Automated Scripts Cleanup

### DIFF
--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -1,17 +1,3 @@
-# /etc/crontab: system-wide crontab
-# Unlike any other crontab you don't have to run the `crontab'
-# command to install the new version when you edit this file
-# and files in /etc/cron.d. These files also have username fields,
-# that none of the other crontabs do.
-
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
-# m h dom mon dow user  command
-17 *    * * *   root    cd / && run-parts --report /etc/cron.hourly
-25 6    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
-47 6    * * 7   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )
-52 6    1 * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
 
 # Pi-hole: Update the ad sources once a week on Sunday at 01:59
 #          Download any updates from the ad lists
@@ -24,3 +10,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Pi-hole: Flush the log daily at 11:58 so it doesn't get out of control
 #          Stats will be viewable in the Web interface thanks to the cron job above
 58 11   * * *   root    /usr/local/bin/piholeLogFlush.sh
+

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,6 +16,12 @@
 #
 # curl -L install.pi-hole.net | bash
 
+# Must be root to install
+if [[ $EUID -ne 0 ]]; then
+   echo "ERROR: You must run this script as a root user"
+   exit 1
+fi
+
 ######## VARIABLES #########
 tmpLog=/tmp/pihole-install.log
 instalLogLoc=/etc/pihole/install.log
@@ -41,13 +47,13 @@ backupLegacyPihole()
 {
 if [[ -f /etc/dnsmasq.d/adList.conf ]];then
 	echo "Original Pi-hole detected.  Initiating sub space transport"
-	sudo mkdir -p /etc/pihole/original/
-	sudo mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
-	sudo mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
-	sudo mv /etc/resolv.conf /etc/pihole/original/resolv.conf.$(date "+%Y-%m-%d")
-	sudo mv /etc/lighttpd/lighttpd.conf /etc/pihole/original/lighttpd.conf.$(date "+%Y-%m-%d")
-	sudo mv /var/www/pihole/index.html /etc/pihole/original/index.html.$(date "+%Y-%m-%d")
-	sudo mv /usr/local/bin/gravity.sh /etc/pihole/original/gravity.sh.$(date "+%Y-%m-%d")
+	mkdir -p /etc/pihole/original/
+	mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
+	mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
+	mv /etc/resolv.conf /etc/pihole/original/resolv.conf.$(date "+%Y-%m-%d")
+	mv /etc/lighttpd/lighttpd.conf /etc/pihole/original/lighttpd.conf.$(date "+%Y-%m-%d")
+	mv /var/www/pihole/index.html /etc/pihole/original/index.html.$(date "+%Y-%m-%d")
+	mv /usr/local/bin/gravity.sh /etc/pihole/original/gravity.sh.$(date "+%Y-%m-%d")
 else
 	:
 fi
@@ -121,8 +127,8 @@ useIPv6dialog()
 {
 piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
 whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$piholeIPv6 will be used to block ads." $r $c
-sudo mkdir -p /etc/pihole/
-sudo touch /etc/pihole/.useIPv6
+mkdir -p /etc/pihole/
+touch /etc/pihole/.useIPv6
 }
 
 getStaticIPv4Settings()
@@ -189,7 +195,7 @@ setDHCPCD(){
 echo "interface $piholeInterface
 static ip_address=$IPv4addr
 static routers=$IPv4gw
-static domain_name_servers=$IPv4gw" | sudo tee -a $dhcpcdFile >/dev/null
+static domain_name_servers=$IPv4gw" | tee -a $dhcpcdFile >/dev/null
 }
 
 setStaticIPv4(){
@@ -198,75 +204,75 @@ if grep -q $IPv4addr $dhcpcdFile; then
 	:
 else
 	setDHCPCD
-	sudo ip addr replace dev $piholeInterface $IPv4addr
+	ip addr replace dev $piholeInterface $IPv4addr
 	echo "Setting IP to $IPv4addr.  You may need to restart after the install is complete."
 fi
 }
 
 installScripts(){
-sudo curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
-sudo curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
-sudo curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
-sudo curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh
-sudo chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,piholeLogFlush}.sh
+curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
+curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
+curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
+curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh
+chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,piholeLogFlush}.sh
 }
 
 installConfigs(){
-sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
-sudo mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
-sudo curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
-sudo curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
-sudo sed -i "s/@INT@/$piholeInterface/" /etc/dnsmasq.conf
+mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
+mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
+curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
+curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
+sed -i "s/@INT@/$piholeInterface/" /etc/dnsmasq.conf
 }
 
 stopServices(){
-sudo service dnsmasq stop || true
-sudo service lighttpd stop || true
+service dnsmasq stop || true
+service lighttpd stop || true
 }
 
 installDependencies(){
-sudo apt-get update
-sudo apt-get -y upgrade
-sudo apt-get -y install dnsutils bc toilet
-sudo apt-get -y install dnsmasq
-sudo apt-get -y install lighttpd php5-common php5-cgi php5
+apt-get update
+apt-get -y upgrade
+apt-get -y install dnsutils bc toilet
+apt-get -y install dnsmasq
+apt-get -y install lighttpd php5-common php5-cgi php5
 }
 
 installWebAdmin(){
-sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip
-sudo unzip -oq /var/www/master.zip -d /var/www/html/
-sudo mv /var/www/html/AdminLTE-master /var/www/html/admin
-sudo rm /var/www/master.zip 2>/dev/null
-sudo touch /var/log/pihole.log
-sudo chmod 644 /var/log/pihole.log
-sudo chown dnsmasq:root /var/log/pihole.log
+wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip
+unzip -oq /var/www/master.zip -d /var/www/html/
+mv /var/www/html/AdminLTE-master /var/www/html/admin
+rm /var/www/master.zip 2>/dev/null
+touch /var/log/pihole.log
+chmod 644 /var/log/pihole.log
+chown dnsmasq:root /var/log/pihole.log
 }
 
 installPiholeWeb(){
-sudo mkdir /var/www/html/pihole
-sudo mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
-sudo curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html
+mkdir /var/www/html/pihole
+mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
+curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html
 }
 
 installCron(){
-sudo mv /etc/crontab /etc/crontab.orig
-sudo curl -o /etc/crontab https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
+mv /etc/crontab /etc/crontab.orig
+curl -o /etc/crontab https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
 }
 
 installPihole()
 {
 installDependencies
 stopServices
-sudo chown www-data:www-data /var/www/html
-sudo chmod 775 /var/www/html
-sudo usermod -a -G www-data pi
-sudo lighty-enable-mod fastcgi fastcgi-php
+chown www-data:www-data /var/www/html
+chmod 775 /var/www/html
+usermod -a -G www-data pi
+lighty-enable-mod fastcgi fastcgi-php
 installScripts
 installConfigs
 installWebAdmin
 installPiholeWeb
 installCron
-sudo /usr/local/bin/gravity.sh
+/usr/local/bin/gravity.sh
 }
 
 displayFinalMessage(){
@@ -317,9 +323,9 @@ fi
 installPihole | tee $tmpLog
 
 # Move the log file into /etc/pihole for storage
-sudo mv $tmpLog $instalLogLoc
+mv $tmpLog $instalLogLoc
 
 displayFinalMessage
 
-sudo service dnsmasq start
-sudo service lighttpd start
+service dnsmasq start
+service lighttpd start

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -17,9 +17,9 @@
 # curl -L install.pi-hole.net | bash
 
 # Must be root to install
-if [[ $EUID -ne 0 ]]; then
-   echo "ERROR: You must run this script as a root user"
-   exit 1
+if [[ $EUID -ne 0  ]]; then
+    sudo bash "$0" "$@"
+    exit $?
 fi
 
 ######## VARIABLES #########

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -255,8 +255,11 @@ curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobs
 }
 
 installCron(){
-mv /etc/crontab /etc/crontab.orig
-curl -o /etc/crontab https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
+curl -o /etc/cron.d/pihole https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
+
+# in most cases, cron should pickup pihole automatically but to avoid
+# any edge cases, the service should be restarted.
+service cron restart
 }
 
 installPihole()

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -20,8 +20,23 @@ apt-get -y remove --purge dnsmasq
 apt-get -y remove --purge lighttpd php5-common php5-cgi php5
 rm -rf /var/www/html
 rm /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
-rm /etc/crontab
-mv /etc/crontab.orig /etc/crontab
+
+# attempt to preserve backwards compatibility with older versions
+# to gaurentee no additional changes were made to /etc/crontab after
+# the installation of pihole, /etc/crontab.pihole should be permanently
+# preserved.
+# @TODO: debugging statement alerting user of this.
+if [ -f /etc/crontab.orig ]; then
+	mv /etc/crontab /etc/crontab.pihole
+	mv /etc/crontab.orig /etc/crontab
+	service cron restart
+fi
+
+# attempt to preserve backwards compatibility with older versions
+if [ -f /etc/cron.d/pihole ]; then
+	rm /etc/cron.d/pihole
+fi
+
 rm /etc/dnsmasq.conf
 rm -rf /etc/lighttpd/
 rm /var/log/pihole.log

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -8,20 +8,25 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+# Must be root to uninstall
+if [[ $EUID -ne 0 ]]; then
+   echo "ERROR: You must run this script as a root user" 
+   exit 1
+fi
 
 ######### SCRIPT ###########
-sudo apt-get -y remove --purge dnsutils bc toilet
-sudo apt-get -y remove --purge dnsmasq
-sudo apt-get -y remove --purge lighttpd php5-common php5-cgi php5
-sudo rm -rf /var/www/html
-sudo rm /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
-sudo rm /etc/crontab
-sudo mv /etc/crontab.orig /etc/crontab
-sudo rm /etc/dnsmasq.conf
-sudo rm -rf /etc/lighttpd/
-sudo rm /var/log/pihole.log
-sudo rm /usr/local/bin/gravity.sh
-sudo rm /usr/local/bin/chronometer.sh
-sudo rm /usr/local/bin/whitelist.sh
-sudo rm /usr/local/bin/piholeLogFlush.sh
-sudo rm -rf /etc/pihole/
+apt-get -y remove --purge dnsutils bc toilet
+apt-get -y remove --purge dnsmasq
+apt-get -y remove --purge lighttpd php5-common php5-cgi php5
+rm -rf /var/www/html
+rm /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
+rm /etc/crontab
+mv /etc/crontab.orig /etc/crontab
+rm /etc/dnsmasq.conf
+rm -rf /etc/lighttpd/
+rm /var/log/pihole.log
+rm /usr/local/bin/gravity.sh
+rm /usr/local/bin/chronometer.sh
+rm /usr/local/bin/whitelist.sh
+rm /usr/local/bin/piholeLogFlush.sh
+rm -rf /etc/pihole/

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -9,10 +9,11 @@
 # (at your option) any later version.
 
 # Must be root to uninstall
-if [[ $EUID -ne 0 ]]; then
-   echo "ERROR: You must run this script as a root user" 
-   exit 1
+if [[ $EUID -ne 0  ]]; then
+    sudo bash "$0" "$@"
+    exit $?
 fi
+
 
 ######### SCRIPT ###########
 apt-get -y remove --purge dnsutils bc toilet

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -23,7 +23,8 @@ apt-get -y remove --purge lighttpd php5-common php5-cgi php5
 # be removed. if the web directory is empty after removing
 # these files, then the parent html folder can be removed.
 rm -rf /var/www/html/admin
-rm -rf /var/www/html/pihold
+rm -rf /var/www/html/pihole
+rm /var/www/html/index.lighttpd.orig
 if [ ! "$(ls -A /var/www/html)" ]; then
     rm -rf /var/www/html
 fi

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -18,7 +18,16 @@ fi
 apt-get -y remove --purge dnsutils bc toilet
 apt-get -y remove --purge dnsmasq
 apt-get -y remove --purge lighttpd php5-common php5-cgi php5
-rm -rf /var/www/html
+
+# only web directories/files that are created by pihole should
+# be removed. if the web directory is empty after removing
+# these files, then the parent html folder can be removed.
+rm -rf /var/www/html/admin
+rm -rf /var/www/html/pihold
+if [ ! "$(ls -A /var/www/html)" ]; then
+    rm -rf /var/www/html
+fi
+
 rm /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
 
 # attempt to preserve backwards compatibility with older versions


### PR DESCRIPTION
The automated installation/removal scripts have some room for optimizations and improvements. This is the first wave of proposed changes in this PR:

* Install script now installs pihole crons to /etc/cron.d/pihole instead of /etc/crontab (which should never be touched by an automated process). The uninstall script takes this into account and also attempts to provide backwards comparability when uninstalling pihole.
*  Uninstall script now gracefully handles /var/www/html removal. Its not safe to assume when uninstalling that the entire /var/www/html directory should be removed.
* Removed sudo commands from install and uninstall scripts - script now requires a user with root permissions to run. Will receive "ERROR: You must run this script as a root user" message when running either as a non-root user.