### PR TITLE
replaces the non-repository managed web interface for pihole and keep…

### DIFF
--- a/automated install/webinterface.sh
+++ b/automated install/webinterface.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# this script will update the pihole web interface files.
+#
+# if this is the first time running this script after an 
+# existing installation, the existing web interface files
+# will be removed and replaced with the latest master
+# branch from github. subsequent executions of this script
+# will pull the latest version of the web interface.
+#
+# @TODO: add git as requirement to basic-install.sh
+#
+
+WEB_INTERFACE_GIT_URL="https://github.com/jacobsalmela/AdminLTE.git"
+WEB_INTERFACE_DIR="/var/www/html/admin"
+
+main() {
+    prerequisites
+    if ! is_repo; then
+        make_repo
+    fi
+    update_repo
+}
+
+prerequisites() {
+
+    # must be root to update
+    if [[ $EUID -ne 0 ]]; then
+        sudo bash "$0" "$@"
+        exit $?
+    fi
+
+    # web interface must already exist. this is a (lazy)
+    # check to make sure pihole is actually installed.
+    if [ ! -d "$WEB_INTERFACE_DIR" ]; then
+        echo "$WEB_INTERFACE_DIR not found. Exiting."
+        exit 1
+    fi
+
+    if ! type "git" > /dev/null; then
+        apt-get -y install git
+    fi
+}
+
+is_repo() {
+    # if the web interface directory does not have a .git folder
+    # it means its using the master.zip archive from the install
+    # script.
+    if [ ! -d "$WEB_INTERFACE_DIR/.git" ]; then
+        return 1
+    fi
+    return 0
+}
+
+# removes the web interface installed from the master.zip archive and
+# replaces it with the current master branch from github
+make_repo() {
+    # remove the non-repod interface and clone the interface
+    rm -rf $WEB_INTERFACE_DIR
+    git clone "$WEB_INTERFACE_GIT_URL" "$WEB_INTERFACE_DIR"
+}
+
+# pulls the latest master branch from github
+update_repo() {
+    # pull the latest commits
+    cd "$WEB_INTERFACE_DIR"
+    git pull    
+}
+
+main


### PR DESCRIPTION
This PR will replace the non-managed /var/www/html/admin directory with the git managed repo.

**The first time the script is ran on an existing installation, it will:**
* Remove the existing /var/www/html/admin directory
* Clone jacobsalema/AdminLTE to /var/www/html/admin

**Subsequent runs of this script will:**
* Pull the latest master branch from jaconsalema/AdminLTE to /var/www/html/admin

I'm not sure if this fits in the scope of what you hope to do with pi-hole, but if it does I would like to call this script in the basic-install.sh process. There would need to be some minor tweaks, but I think it would make updating the web interface a trivial process. 

**Below is the process debug:**

**First Time Run:**

```
# bash update-webinterface.sh 
+ WEB_INTERFACE_GIT_URL=https://github.com/jacobsalmela/AdminLTE.git
+ WEB_INTERFACE_DIR=/var/www/html/admin
+ main
+ prerequisites
+ [[ 0 -ne 0 ]]
+ '[' '!' -d /var/www/html/admin ']'
+ type git
+ is_repo
+ '[' '!' -d /var/www/html/admin/.git ']'
+ return 1
+ make_repo
+ rm -rf /var/www/html/admin
+ git clone https://github.com/jacobsalmela/AdminLTE.git /var/www/html/admin
Cloning into '/var/www/html/admin'...
remote: Counting objects: 7229, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 7229 (delta 1), reused 0 (delta 0), pack-reused 7222
Receiving objects: 100% (7229/7229), 17.30 MiB | 1.28 MiB/s, done.
Resolving deltas: 100% (4074/4074), done.
Checking connectivity... done.
+ update_repo
+ cd /var/www/html/admin
+ git pull
Already up-to-date.
```

**Subsequent Runs:**
```
# bash update-webinterface.sh 
+ WEB_INTERFACE_GIT_URL=https://github.com/jacobsalmela/AdminLTE.git
+ WEB_INTERFACE_DIR=/var/www/html/admin
+ main
+ prerequisites
+ [[ 0 -ne 0 ]]
+ '[' '!' -d /var/www/html/admin ']'
+ type git
+ is_repo
+ '[' '!' -d /var/www/html/admin/.git ']'
+ return 0
+ update_repo
+ cd /var/www/html/admin
+ git pull
Already up-to-date.
```