### PR TITLE
Install Figlet Fonts with Toilet

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -227,7 +227,7 @@ sudo service lighttpd stop || true
 installDependencies(){
 sudo apt-get update
 sudo apt-get -y upgrade
-sudo apt-get -y install dnsutils bc toilet
+sudo apt-get -y install dnsutils bc toilet figlet
 sudo apt-get -y install dnsmasq
 sudo apt-get -y install lighttpd php5-common php5-cgi php5
 }


### PR DESCRIPTION
Some OS' don't have Figlet Fonts, which causes `chronometer.sh` to have `error: font small not found` instead of the pretty "Pi-hole" display