### PR TITLE
Allow other pages to be served from lighttpd & add text to ad blocking page

### DIFF
--- a/advanced/index.html
+++ b/advanced/index.html
@@ -1,4 +1,5 @@
 <html>
 <body>
+Blocked by Pi-hole
 </body>
 </html>

--- a/advanced/lighttpd.conf
+++ b/advanced/lighttpd.conf
@@ -37,15 +37,3 @@ $HTTP["url"] =~ "^/admin/" {
 	# Create a response header for debugging using curl -I
 	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
 }
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-
-	# Set the cache to 1 day for better performance
-	expire.url = ("" => "access plus 1 days")
-
-	# Send the query into the black hole
-	url.rewrite = (".*" => "pihole/index.html" )
-}

--- a/advanced/lighttpd.conf
+++ b/advanced/lighttpd.conf
@@ -37,3 +37,9 @@ $HTTP["url"] =~ "^/admin/" {
 	# Create a response header for debugging using curl -I
 	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
 }
+
+# If the URL does not start with /admin, then it is a query for an ad domain
+$HTTP["url"] =~ "^(?!/admin)/.*" {
+	# Create a response header for debugging using curl -I
+	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
+}


### PR DESCRIPTION
Removes redirect if page is not the admin site. Adds text ("Blocked by Pi-hole") to ad blocking page to let the user know why they received a blank page.
See #182 